### PR TITLE
Fix resume logic slurm multicluster 

### DIFF
--- a/templates/slurm.conf.j2
+++ b/templates/slurm.conf.j2
@@ -164,8 +164,7 @@ SlurmctldTimeout=300
 
 StateSaveLocation={{ slurm_slurmctld_spool_path | default('/var/spool/slurmctld') }}
 
-#SlurmctldDebug=info
-SlurmctldDebug=error
+SlurmctldDebug=info
 SlurmctldLogFile=/var/log/slurm/slurmctld.log
 DebugFlags=backfill,cpu_bind,priority,reservation,selecttype,steps
 
@@ -184,7 +183,7 @@ SlurmdPidFile=/run/slurmd.pid
 SlurmdSpoolDir={{ slurm_slurmd_spool_path | default('/var/spool/slurm') }}
 SlurmdTimeout=300
 
-SlurmdDebug=verbose
+SlurmdDebug=info
 SlurmdLogFile=/var/log/slurm/slurmd.log
 
 AuthType=auth/munge

--- a/templates/slurm_resume_openstack.py.j2
+++ b/templates/slurm_resume_openstack.py.j2
@@ -197,10 +197,10 @@ def create_server(conn, name, image, flavor, network, keypair, security_groups):
     #logger.info(f"Node {name} has booted with ip {server_ip}")
     #return server, server_ip
 
-    # Try fix resource exhaustion issue when running multiple slurm cluster on same openstack cloud
-    # Check if VM is on error state after spawning. This means that slurm will set it down eventually,
-    # unless the VM is cleaned properly. Error state happens when hypervisors are fully allocated and a VM is requested by slurm.
-    # slurm cannot handle this and puts compute node to down state which needs to be manually resumed.
+    #try fix resource exhaustion issue when running multiple slurm cluster on same openstack cloud
+    #check if VM is on error state after spawning. This means that slurm will set it down eventually,
+    #unless the VM is cleaned properly. Error state happens when hypervisors are fully allocated and a VM is requested by slurm.
+    #slurm cannot handle this and puts compute node to down state which needs to be manually resumed.
     try:
       server = conn.compute.wait_for_server(server, wait=60)
     except ResourceFailure as e:

--- a/templates/slurm_resume_openstack.py.j2
+++ b/templates/slurm_resume_openstack.py.j2
@@ -42,6 +42,8 @@
 import sys, os, subprocess, logging.handlers
 import openstack
 import pprint
+import time
+from openstack.exceptions import ResourceFailure
 
 # configure logging to syslog - by default only "info" and above categories appear
 logger = logging.getLogger("syslogger")
@@ -194,6 +196,19 @@ def create_server(conn, name, image, flavor, network, keypair, security_groups):
     #server_ip = next(conn.compute.server_ips(server)).address  # conn.compute.server_ips() returns an iterator. Use next() to get first element
     #logger.info(f"Node {name} has booted with ip {server_ip}")
     #return server, server_ip
+
+    # Try fix resource exhaustion issue when running multiple slurm cluster on same openstack cloud
+    # Check if VM is on error state after spawning. This means that slurm will set it down eventually,
+    # unless the VM is cleaned properly. Error state happens when hypervisors are fully allocated and a VM is requested by slurm.
+    # slurm cannot handle this and puts compute node to down state which needs to be manually resumed.
+    try:
+      server = conn.compute.wait_for_server(server, wait=60)
+    except ResourceFailure as e:
+        logger.error(f"Instance failed to spawn with exception {e}")
+        conn.compute.delete_server(server)
+        logger.error(f"Deleted server in error state: {server.id}")
+    except Exception as e:
+        logger.error(f"Server deletion failed. {e}")
 
     return server
 


### PR DESCRIPTION
Lately we ran into issue where OpenStack nova-scheduler runs out of resources, when providing computing nodes to dynamic Slurm in multiple projects.
Slurm was not able to handle the half-existing node in ERROR state, so slurm clusters started to have more and more nodes in DOWN state which requires manual cleaning.
I propose to add logic to resume script of dynamic node, so errorneous node gets deleted before causing problems in the slurm cluster.